### PR TITLE
Fix link to lnurl-auth jmolecules example app

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -8,4 +8,7 @@ This repository contains examples that showcase the usage of jMolecules and jMol
 
 == External examples
 
+
 * https://github.com/odrotbohm/spring-restbucks[Spring RESTBucks] -- a hypermedia-based REST service exposing a coffee ordering business process. Uses jMolecules integrations for Spring, Jackson and persistence code generation via the jMolecules ByteBuddy plugin.
+* https://github.com/theborakompanioni/bitcoin-spring-boot-starter/tree/master/incubator/spring-lnurl/spring-lnurl-auth-example-application[LNURL Auth] -- A showcase application using jMolecules integrations.
+


### PR DESCRIPTION
Link was broken due to moving the application into own `spring-lnurl` module within the repository.